### PR TITLE
fix(ECR): add depends_on=repos-resource to repo-policy resource

### DIFF
--- a/AWS_ECR/main.ECR_RepoPolicies.tf
+++ b/AWS_ECR/main.ECR_RepoPolicies.tf
@@ -16,6 +16,8 @@ resource "aws_ecr_repository_policy" "map" {
         jsondecode(each.value.policy_config.custom_statements_json)
       )
   }))
+
+  depends_on = [aws_ecr_repository.map]
 }
 
 data "aws_iam_policy_document" "Repo_Policies_Map" {


### PR DESCRIPTION
### Type of Change

- [ ] Breaking change
- [ ] New feature/functionality
- [ ] Improves existing feature/functionality
- [ ] Refactor
- [x] Bug fix
- [ ] Chore
- [ ] Documentation
- [ ] Stylistic change

### Description of Change

Add `depends_on = [aws_ecr_repository.map]` to repo policy resource to fix resource creation-order issue.
